### PR TITLE
Multiple cache types

### DIFF
--- a/blacklist.go
+++ b/blacklist.go
@@ -1,0 +1,51 @@
+package malicious
+
+import "github.com/alecthomas/mph"
+
+type Blacklist interface {
+	Add(key string)
+	Contains(key string) bool
+	Close() error
+	Len() int
+	Open()
+}
+
+// type BlacklistBuilder interface {
+// 	New(b Blacklist) Blacklist
+// }
+
+func NewBlacklist() Blacklist {
+	b := &MPHBlacklist{}
+	b.Open()
+	return b
+}
+
+type MPHBlacklist struct {
+	blacklist *mph.CHD
+	builder   *mph.CHDBuilder
+}
+
+func (m *MPHBlacklist) Add(key string) {
+	m.builder.Add([]byte(key), []byte(""))
+}
+
+func (m *MPHBlacklist) Contains(key string) bool {
+	hit := m.blacklist.Get([]byte(key))
+	return hit != nil
+}
+
+func (m *MPHBlacklist) Close() error {
+	blacklist, err := m.builder.Build()
+
+	m.blacklist = blacklist
+
+	return err
+}
+
+func (m *MPHBlacklist) Len() int {
+	return m.blacklist.Len()
+}
+
+func (m *MPHBlacklist) Open() {
+	m.builder = mph.Builder()
+}

--- a/domains.go
+++ b/domains.go
@@ -1,0 +1,73 @@
+package malicious
+
+import (
+	"bufio"
+	"io"
+	"os"
+	"strings"
+)
+
+const (
+	DomainFileFormatHostfile = "hostfile"
+	DomainFileFormatTextList = "text"
+	DomainSourceTypeFile     = "file"
+	DomainSourceTypeURL      = "url"
+)
+
+func domainsGenerator(source string, sourceType string, sourceFormat string) chan string {
+
+	c := make(chan string)
+
+	go func() {
+		defer close(c)
+		// TODO: handle URL vs file
+		// if sourceType == DomainSourceTypeFile {
+
+		// } else if sourceType == DomainSourceTypeURL {
+		// 	// TODO
+
+		// }
+
+		sourceData, err := os.Open(source)
+		if err != nil {
+			log.Error(err)
+		}
+		defer sourceData.Close()
+
+		scanner := bufio.NewScanner(sourceData)
+		for scanner.Scan() {
+			domain := strings.TrimSpace(scanner.Text())
+			if strings.HasPrefix(domain, "#") {
+				// Skip comment lines
+				continue
+			}
+
+			if domain == "" {
+				// Skip empty lines
+				continue
+			}
+
+			if sourceFormat == DomainFileFormatHostfile {
+				domain = strings.Fields(domain)[1] // Assumes hostfile format:   127.0.0.1  some.host
+			}
+
+			// Assume all domains are global origin, with trailing dot (e.g. example.com.)
+			if !strings.HasSuffix(domain, ".") {
+				domain += "."
+			}
+			// log.Info("Adding ", domain, " to domain blacklist")
+			c <- domain
+		}
+		if err := scanner.Err(); err != nil {
+			log.Error(err)
+		}
+		// close(c)
+	}()
+
+	return c
+
+}
+
+func domainsFromFile(file io.Reader, fileType string) []string {
+	return []string{}
+}

--- a/go.sum
+++ b/go.sum
@@ -179,6 +179,7 @@ github.com/golang/protobuf v1.3.0/go.mod h1:Qd/q+1AKNOZr9uGQzbzCmRO6sUih6GTPZv6a
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.3/go.mod h1:vzj43D7+SQXF/4pzW/hwtAqwc6iTitCiVSaWz5lYuqw=
+github.com/golang/protobuf v1.3.5 h1:F768QJ1E9tib+q5Sc8MkdJi1RxLTbRcTf8LJV56aRls=
 github.com/golang/protobuf v1.3.5/go.mod h1:6O5/vntMXwX2lRkT1hjjk0nAC1IDOTvTlVgjlRvqsdk=
 github.com/golang/protobuf v1.4.0-rc.1/go.mod h1:ceaxUfeHdC40wWswd/P6IGgMaK3YpKi5j83Wpe3EHw8=
 github.com/golang/protobuf v1.4.0-rc.1.0.20200221234624-67d41d38c208/go.mod h1:xKAWHe0F5eneWXFV3EuXVDTCmh+JuBKY0li0aMyXATA=
@@ -263,6 +264,7 @@ github.com/kolo/xmlrpc v0.0.0-20190717152603-07c4ee3fd181/go.mod h1:o03bZfuBwAXH
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
+github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.0 h1:s5hAObm+yFO5uHYt5dYjxi2rXrsnmRpJx4OYvIWUaQs=
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
@@ -348,6 +350,7 @@ github.com/prometheus/client_model v0.2.0/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6T
 github.com/prometheus/common v0.2.0/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y86RQel1bk4=
 github.com/prometheus/common v0.4.1/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y86RQel1bk4=
 github.com/prometheus/common v0.6.0/go.mod h1:eBmuwkDJBwy6iBfxCBob6t6dR6ENT/y+J+Zk0j9GMYc=
+github.com/prometheus/common v0.9.1 h1:KOMtN28tlbam3/7ZKEYKHhKoJZYYj3gMH4uc62x7X7U=
 github.com/prometheus/common v0.9.1/go.mod h1:yhUN8i9wzaXS3w1O07YhxHEBxD+W35wd8bs7vj7HSQ4=
 github.com/prometheus/common v0.10.0 h1:RyRA7RzGXQZiW+tGMr7sxa85G1z0yOpM1qq5c8lNawc=
 github.com/prometheus/common v0.10.0/go.mod h1:Tlit/dnDKsSWFlCLTWaA1cyBgKHSMdTB80sz/V91rCo=
@@ -383,6 +386,7 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
@@ -429,6 +433,7 @@ golang.org/x/crypto v0.0.0-20191002192127-34f69633bfdc/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20191202143827-86a70503ff7e/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20191206172530-e9b2fee46413/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/crypto v0.0.0-20200220183623-bac4c82f6975 h1:/Tl7pH94bvbAAHBdZJT947M/+gp0+CqQXDtMRC0fseo=
 golang.org/x/crypto v0.0.0-20200220183623-bac4c82f6975/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200323165209-0ec3e9974c59 h1:3zb4D3T4G8jdExgVU/95+vQXfpEPiMdCaZgmGVxjNHM=
 golang.org/x/crypto v0.0.0-20200323165209-0ec3e9974c59/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
@@ -503,6 +508,7 @@ golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e h1:vcxGaoTs7kV8m5Np9uUNQin4BrLOthgV7252N8V+FwY=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a h1:WXEvlFVvvGxCJLG6REjsT03iWnKLEWinaScsxF2Vm2o=
 golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -647,6 +653,7 @@ google.golang.org/grpc v1.25.1/go.mod h1:c3i+UQWmh7LiEpx4sFZnkU36qjEYZ0imhYfXVyQ
 google.golang.org/grpc v1.26.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
 google.golang.org/grpc v1.27.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
 google.golang.org/grpc v1.27.1/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
+google.golang.org/grpc v1.28.0 h1:bO/TA4OxCOummhSf10siHuG7vJOiwh7SpRpFZDkOgl4=
 google.golang.org/grpc v1.28.0/go.mod h1:rpkK4SK4GF4Ach/+MFLZUBavHOvF2JJB5uozKKal+60=
 google.golang.org/grpc v1.29.1 h1:EC2SB8S04d2r73uptxphDSUG+kTKVgjRPF+N3xpxRB4=
 google.golang.org/grpc v1.29.1/go.mod h1:itym6AZVZYACWQqET3MqgPpjcuV5QH3BxFS3IjizoKk=

--- a/malicious.go
+++ b/malicious.go
@@ -46,11 +46,16 @@ func (e *Malicious) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.M
 
 	if e.blacklist != nil {
 		// See if the requested domain is in the cache
-		// hit := e.blacklist.Get([]byte(req.Name()))
-		if e.blacklist.Contains(req.Name()) {
+		retrievalStart := time.Now()
+		hit := e.blacklist.Contains(req.Name())
+		// Record the duration for the query
+		blacklistCheckDuration.WithLabelValues(metrics.WithServer(ctx)).Observe(time.Since(retrievalStart).Seconds())
+
+		if hit {
 			blacklistCount.WithLabelValues(metrics.WithServer(ctx), req.IP(), req.Name()).Inc()
-			log.Info("host ", req.IP(), " requested blacklisted domain: ", req.Name())
+			log.Warning("host ", req.IP(), " requested blacklisted domain: ", req.Name())
 		}
+
 	} else {
 		log.Warning("no blacklist has been loaded")
 	}
@@ -66,7 +71,7 @@ func (e *Malicious) reloadBlacklist(ctx context.Context) {
 	newBlacklist, err := buildCacheFromFile(e.Options.DomainFileName)
 	if err != nil {
 		if strings.Contains(err.Error(), "failed to find a collision-free hash function") {
-			// Special case where there are 2^n objects in the blacklist
+			// Special case where there are 2^n objects in the mph blacklist
 			log.Error("error rebuilding blacklist: number of items must not be a power of 2 (sorry)")
 		} else {
 			log.Error("error rebuilding blacklist: ", err)

--- a/malicious.go
+++ b/malicious.go
@@ -13,7 +13,6 @@ import (
 	"github.com/coredns/coredns/plugin/metrics"
 	clog "github.com/coredns/coredns/plugin/pkg/log"
 
-	"github.com/alecthomas/mph"
 	"github.com/miekg/dns"
 )
 
@@ -24,7 +23,7 @@ var log = clog.NewWithPlugin("malicious")
 // Malicious is a plugin which counts requests to blacklisted domains
 type Malicious struct {
 	Next           plugin.Handler
-	blacklist      *mph.CHD
+	blacklist      Blacklist
 	lastReloadTime time.Time
 	Options        PluginOptions
 	// quit           chan bool
@@ -47,8 +46,8 @@ func (e *Malicious) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.M
 
 	if e.blacklist != nil {
 		// See if the requested domain is in the cache
-		hit := e.blacklist.Get([]byte(req.Name()))
-		if hit != nil {
+		// hit := e.blacklist.Get([]byte(req.Name()))
+		if e.blacklist.Contains(req.Name()) {
 			blacklistCount.WithLabelValues(metrics.WithServer(ctx), req.IP(), req.Name()).Inc()
 			log.Info("host ", req.IP(), " requested blacklisted domain: ", req.Name())
 		}

--- a/metrics.go
+++ b/metrics.go
@@ -22,4 +22,11 @@ var reloadsFailedCount = prometheus.NewCounterVec(prometheus.CounterOpts{
 	Help:      "Counter of the number of times the plugin has failed to reload its blacklist.",
 }, []string{"server"})
 
+var blacklistCheckDuration = prometheus.NewSummaryVec(prometheus.SummaryOpts{
+	Namespace: plugin.Namespace,
+	Subsystem: "malicious_domain",
+	Name:      "malicious_domain_cache_check_duration_seconds",
+	Help:      "Estimate of the average duration required to check the cache for a blacklisted domain.",
+}, []string{"server"})
+
 var once sync.Once


### PR DESCRIPTION
Adds:
- stupid fix for MPH 2^n problem - add "some.bogus" as a blacklisted domain so the total is no longer 2^n
- prometheus metric - summary of the cache check duration
- add go map cache type as default
- support hostfile and text list formats sort of